### PR TITLE
STYLE: Update python scripts to use print function for python 3.x

### DIFF
--- a/Elastix/Elastix.py
+++ b/Elastix/Elastix.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer
@@ -327,7 +328,7 @@ class ElastixWidget(ScriptedLoadableModuleWidget):
         movingVolumeMaskNode = self.movingVolumeMaskSelector.currentNode())
 
     except Exception as e:
-      print e
+      print(e)
       self.addLog("Error: {0}".format(e.message))
       import traceback
       traceback.print_exc()


### PR DESCRIPTION
This commit was crafted following these steps:

- installing future

```
  Slicer_DIR=/path/to/Slicer-SuperBuild/Slicer-build
  ${Slicer_DIR}/../python-install/bin/PythonSlicer -m pip install future
```

- applying the "libfuturize.fixes.fix_absolute_import" fix

```
  for f in `find ./ -name "*.py"`; do \
    ${Slicer_DIR}/../python-install/bin/PythonSlicer \
      --launch futurize -f libfuturize.fixes.fix_print_with_import --nobackups --write $f; \
  done
```