### PR TITLE
ENH: Update elastix

### DIFF
--- a/SuperBuild/External_elastix.cmake
+++ b/SuperBuild/External_elastix.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     BINARY_DIR ${proj}-build
     INSTALL_DIR ${${proj}_INSTALL_DIR}
     GIT_REPOSITORY "${git_protocol}://github.com/SuperElastix/elastix.git"
-    GIT_TAG "d506b227560307c85122f2711894bebffb149f6b"
+    GIT_TAG "465fad42a9b4f2861ee034f098c9c71074881f2c"
     #--Patch step-------------
     PATCH_COMMAND ${CMAKE_COMMAND} -Delastix_SRC_DIR=${CMAKE_BINARY_DIR}/${proj}
       -P ${CMAKE_CURRENT_LIST_DIR}/${proj}_patch.cmake


### PR DESCRIPTION
See https://github.com/SuperElastix/elastix/pull/128#issuecomment-483637477

List of changes:

$ git shortlog d506b227..465fad42 --no-merges
Niels Dekker (4):
      COMP: Use ModifiedTimeType instead of unsigned long
      STYLE: Replace ITK_OVERRIDE by C++11 override
      COMP: Added override by Clang Tidy-Fix modernize-use-override
      COMP: Added C++11 override to Components