### PR TITLE
COMP: Fix build in Slicer custom app

### DIFF
--- a/SuperBuild/External_elastix.cmake
+++ b/SuperBuild/External_elastix.cmake
@@ -29,7 +29,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   endif()
 
   message(STATUS "ITK version: ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}.")
-  if(${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_LESS 5.0)
+  if(DEFINED ITK_VERSION_MAJOR AND ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_LESS 5.0)
     set(ELASTIX_GIT_REPOSITORY "${git_protocol}://github.com/SuperElastix/elastix.git")
     set(ELASTIX_GIT_TAG "419313e9cc12727d73c7e6e47fbdf960aa1218b9") # latest commit on "develop" branch as if 2019-10-13
   else()


### PR DESCRIPTION
When building SlicerElastix in a Slicer custom application, the ITK version CMake variables are not defined when the decision about the used Elastix repository is made in configuration time. The fix is to use the one for ITK 5 if the variable is not defined.