### PR TITLE
Fix TypeError exception

### DIFF
--- a/Elastix/Elastix.py
+++ b/Elastix/Elastix.py
@@ -441,12 +441,12 @@ class ElastixLogic(ScriptedLoadableModuleLogic):
     """Create an environment for elastix where executables are added to the path"""
     elastixBinDir = self.getElastixBinDir()
     elastixEnv = os.environ.copy()
-    elastixEnv["PATH"] = elastixBinDir + os.pathsep + elastixEnv["PATH"] if elastixEnv.get("PATH") else elastixBinDir
+    elastixEnv["PATH"] = os.path.join(elastixBinDir, elastixEnv["PATH"]) if elastixEnv.get("PATH") else elastixBinDir
 
     import platform
     if platform.system() != 'Windows':
       elastixLibDir = os.path.abspath(os.path.join(elastixBinDir, '../lib'))
-      elastixEnv["LD_LIBRARY_PATH"] = elastixLibDir + os.pathsep + elastixEnv["LD_LIBRARY_PATH"] if elastixEnv.get("LD_LIBRARY_PATH") else elastixLibDir
+      elastixEnv["LD_LIBRARY_PATH"] = os.path.join(elastixLibDir, elastixEnv["LD_LIBRARY_PATH"]) if elastixEnv.get("LD_LIBRARY_PATH") else elastixLibDir
 
     return elastixEnv
 


### PR DESCRIPTION
TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str' These happened in linux for me. This change fixed the behaviour with no more exceptions