### PR TITLE
BUG: Fix registration parameters to avoid simple conversion errors

### DIFF
--- a/Elastix/Resources/RegistrationParameters/Deformable.txt
+++ b/Elastix/Resources/RegistrationParameters/Deformable.txt
@@ -30,7 +30,7 @@
 // ******************** Multiresolution **********************
 
 (NumberOfResolutions 3)
-(ImagePyramidSchedule 8 8 2  4 4 1  1 1 0.5) // ACCOUNTING FOR ANISOTROPIC RESOLUTION
+(ImagePyramidSchedule 8 8 2  4 4 1  1 1 1) // ACCOUNTING FOR ANISOTROPIC RESOLUTION
 
 // ******************* Optimizer ****************************
 

--- a/Elastix/Resources/RegistrationParameters/Parameters.Par0008.affine.txt
+++ b/Elastix/Resources/RegistrationParameters/Parameters.Par0008.affine.txt
@@ -52,7 +52,7 @@
 //Default pixel value for pixels that come from outside the picture:
 (DefaultPixelValue 0)
 
-(ImagePyramidSchedule 8.0 4.0 4.0 2.0 1.0)
+(ImagePyramidSchedule 8 4 4 2 1)
 
 //SP: Param_a in each resolution level. a_k = a/(A+k+1)^alpha
 (SP_a 500.0)

--- a/Elastix/Resources/RegistrationParameters/Parameters.Par0008.elastic.txt
+++ b/Elastix/Resources/RegistrationParameters/Parameters.Par0008.elastic.txt
@@ -32,7 +32,7 @@
 //Final spacing of B-Spline grid (unit = size of 1 voxel):
 (FinalGridSpacingInVoxels 8.0)
 
-(ImagePyramidSchedule 8.0 4.0 4.0 2.0 1.0)
+(ImagePyramidSchedule 8 4 4 2 1)
 (GridSpacingSchedule 8.0 4.0 4.0 2.0 1.0)
 
 (MaximumNumberOfSamplingAttempts 10)

--- a/Elastix/Resources/RegistrationParameters/Rigid.txt
+++ b/Elastix/Resources/RegistrationParameters/Rigid.txt
@@ -28,7 +28,7 @@
 // ******************** Multiresolution **********************
 
 (NumberOfResolutions 3)
-(ImagePyramidSchedule 8 8 2  4 4 1  1 1 0.5 )
+(ImagePyramidSchedule 8 8 2  4 4 1  1 1 1 )
 
 // ******************* Optimizer ****************************
 


### PR DESCRIPTION
The error was:
itk::ExceptionObject (0000008B5D2FF108)
Location: "unknown"
File: D:\D\S\S-0-E-b\SlicerElastix-build\elastix\Common\ParameterFileParser\itkParameterMapInterface.h Line: 188
Description: ITK ERROR: ParameterMapInterface(0000028A2B3C7C80): ERROR: Casting entry number 8 for the parameter "ImagePyramidSchedule" failed!
  You tried to cast "0.5" from std::string to unsigned int