### PR TITLE
COMP: Fix integration of Elastix external project in custom app

### DIFF
--- a/SuperBuild/External_elastix.cmake
+++ b/SuperBuild/External_elastix.cmake
@@ -2,6 +2,11 @@ set(proj elastix)
 set(ep_common_cxx_flags "${CMAKE_CXX_FLAGS_INIT} ${ADDITIONAL_CXX_FLAGS}")
 # Set dependency list
 set(${proj}_DEPENDS "")
+if(DEFINED Slicer_SOURCE_DIR)
+  list(APPEND ${proj}_DEPENDS
+    ITK
+    )
+endif()
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)


### PR DESCRIPTION
This commit ensures Elastix is built against the ITK build tree made available by the custom application build system.

I don't know how to properly credit and thank @jcfr for his commit on SlicerRT that solve our build issue: https://github.com/SlicerRt/SlicerRT/commit/752a03c39c4963e05842feecbb4c71c2db5722aa