### PR TITLE
DOC: Update elastix website URL to https://elastix.dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(SlicerElastix)
 set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerElastix")
 set(EXTENSION_CATEGORY "Registration")
 set(EXTENSION_CONTRIBUTORS "Andras Lasso (PerkLab, Queen's University)")
-set(EXTENSION_DESCRIPTION "This extension makes available Elastix medical image registration toolbox (http://elastix.isi.uu.nl/) available in Slicer.")
+set(EXTENSION_DESCRIPTION "This extension makes available Elastix medical image registration toolbox (https://elastix.dev) available in Slicer.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/lassoan/SlicerElastix/master/SlicerElastix.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/lassoan/SlicerElastix/master/Screenshot01.jpg")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated string, a list or 'NA' if any

--- a/Elastix/Elastix.py
+++ b/Elastix/Elastix.py
@@ -25,17 +25,17 @@ class Elastix(ScriptedLoadableModule):
     self.parent.associatedNodeTypes = ["vtkMRMLScriptedModuleNode"]
     self.parent.dependencies = []
     self.parent.contributors = ["Andras Lasso (PerkLab - Queen's University), Christian Herz (CHOP)"]
-    self.parent.helpText = """Align volumes based on image content using <a href="http://elastix.isi.uu.nl/">Elastix medical image registration toolbox</a>.
+    self.parent.helpText = """Align volumes based on image content using <a href="https://elastix.dev">Elastix medical image registration toolbox</a>.
 <p>Registration troubleshooting: check "Keep temporary files" option before starting regsitration and click on "Show temp folder" to open the folder that contains detailed logs.
 <p>Edit registration parameters: open Advanced section, click "Show database folder", and edit presets. To add a new preset or modify registration phases, modify ElastixParameterSetDatabase.xml.
-See <a href="http://elastix.bigr.nl/wiki/index.php/Parameter_file_database">registration parameter set database</a> and <a href="http://elastix.isi.uu.nl/doxygen/index.html">Elastix documentation</a> for more details."""
+See <a href="http://elastix.bigr.nl/wiki/index.php/Parameter_file_database">registration parameter set database</a> and <a href="https://elastix.dev/doxygen/index.html">Elastix documentation</a> for more details."""
     self.parent.acknowledgementText = """
 This module was originally developed by Andras Lasso (Queen's University, PerkLab)
 to serve as a frontend to Elastix medical image registration toolbox.
 If you use this module, please cite the following articles:
-<ul><li>S. Klein, M. Staring, K. Murphy, M.A. Viergever, J.P.W. Pluim, "<a href="http://elastix.isi.uu.nl/marius/publications/2010_j_TMI.php">elastix: a toolbox for intensity based medical image registration</a>", IEEE Transactions on Medical Imaging, vol. 29, no. 1, pp. 196 - 205, January 2010.</li>
-<li>D.P. Shamonin, E.E. Bron, B.P.F. Lelieveldt, M. Smits, S. Klein and M. Staring, "<a href="http://elastix.isi.uu.nl/marius/publications/2014_j_FNI.php">Fast Parallel Image Registration on CPU and GPU for Diagnostic Classification of Alzheimer's Disease</a>", Frontiers in Neuroinformatics, vol. 7, no. 50, pp. 1-15, January 2014.</li></ul>
-See more information about Elastix medical image registration toolbox at <a href="http://elastix.isi.uu.nl/">http://elastix.isi.uu.nl/</a>.
+<ul><li>S. Klein, M. Staring, K. Murphy, M.A. Viergever, J.P.W. Pluim, "<a href="https://elastix.dev/marius/publications/2010_j_TMI.php">elastix: a toolbox for intensity based medical image registration</a>", IEEE Transactions on Medical Imaging, vol. 29, no. 1, pp. 196 - 205, January 2010.</li>
+<li>D.P. Shamonin, E.E. Bron, B.P.F. Lelieveldt, M. Smits, S. Klein and M. Staring, "<a href="https://elastix.dev/marius/publications/2014_j_FNI.php">Fast Parallel Image Registration on CPU and GPU for Diagnostic Classification of Alzheimer's Disease</a>", Frontiers in Neuroinformatics, vol. 7, no. 50, pp. 1-15, January 2014.</li></ul>
+See more information about Elastix medical image registration toolbox at <a href="https://elastix.dev">https://elastix.dev</a>.
 """
 
 #

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SlicerElastix
-This extension makes available Elastix medical image registration toolkit (https://elastix.lumc.nl) available in Slicer.
+This extension makes available Elastix medical image registration toolkit (https://elastix.dev) available in Slicer.
 
 ![](Screenshot01.jpg)
 


### PR DESCRIPTION
The URLs elastix.lumc.nl and elastix.isi.uu.nl are replaced with elastix.dev.

See also https://github.com/SuperElastix/elastix/discussions/1158