### PR TITLE
ENH: Support elastix version 5.2 with ITK >= 5.4, drop ITK < 5.0

### DIFF
--- a/SuperBuild/External_elastix.cmake
+++ b/SuperBuild/External_elastix.cmake
@@ -26,12 +26,12 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   endif()
 
   message(STATUS "ITK version: ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}.")
-  if(DEFINED ITK_VERSION_MAJOR AND ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_LESS 5.0)
-    set(ELASTIX_GIT_REPOSITORY "$https://github.com/SuperElastix/elastix.git")
-    set(ELASTIX_GIT_TAG "419313e9cc12727d73c7e6e47fbdf960aa1218b9") # latest commit on "develop" branch as if 2019-10-13
-  else()
+  if(DEFINED ITK_VERSION_MAJOR AND ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_LESS 5.4)
     set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
     set(ELASTIX_GIT_TAG "5.1.0") # 2023-01-12
+  else()
+    set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
+    set(ELASTIX_GIT_TAG "5.2.0") # 2024-07-18
   endif()
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
elastix 5.2 is the latest elastix release. It has various enhancements,
performance improvements and bug fixes:
https://github.com/SuperElastix/elastix/releases/tag/5.2.0
elastix version 5.2 requires ITK >= 5.4.

The Superbuild at the main branch of Slicer was upgraded to ITK 5.4.0 by
Dženan Zukić, June 3, 2024, pull request https://github.com/Slicer/Slicer/pull/7771
commit https://github.com/Slicer/Slicer/commit/acf3dd47940665869765584564b38439f73ff1d5

Dropped support of ITK < 5.0. Slicer now requires at least ITK 5.1.0, at the main branch:
https://github.com/Slicer/Slicer/blob/5971cb1e0d95f8592442f886d0d44edba16719ae/SuperBuild/External_ITK.cmake#L18
