### PR TITLE
COMP: Support elastix 5.3.1 with ITK >= 5.4 (builds on #53)

### DIFF
--- a/SuperBuild/External_elastix.cmake
+++ b/SuperBuild/External_elastix.cmake
@@ -31,12 +31,12 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   endif()
 
   message(STATUS "ITK version: ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}.")
-  if(DEFINED ITK_VERSION_MAJOR AND ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_LESS 5.0)
-    set(ELASTIX_GIT_REPOSITORY "$https://github.com/SuperElastix/elastix.git")
-    set(ELASTIX_GIT_TAG "419313e9cc12727d73c7e6e47fbdf960aa1218b9") # latest commit on "develop" branch as if 2019-10-13
-  else()
+  if(DEFINED ITK_VERSION_MAJOR AND ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_LESS 5.4)
     set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
     set(ELASTIX_GIT_TAG "5.1.0") # 2023-01-12
+  else()
+    set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
+    set(ELASTIX_GIT_TAG "5.2.0") # 2024-07-18
   endif()
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_elastix.cmake
+++ b/SuperBuild/External_elastix.cmake
@@ -30,13 +30,16 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     set(${proj}_cxx_flags "${ep_common_cxx_flags} -Wno-inconsistent-missing-override")
   endif()
 
+  if(NOT DEFINED ITK_VERSION_MAJOR)
+    message(FATAL_ERROR "Variable ITK_VERSION_MAJOR is expected to be defined.")
+  endif()
+
   message(STATUS "ITK version: ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}.")
-  if(DEFINED ITK_VERSION_MAJOR AND ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_LESS 5.4)
-    set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-    set(ELASTIX_GIT_TAG "5.1.0") # 2023-01-12
+  set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
+  if(${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_GREATER_EQUAL 5.4)
+    set(ELASTIX_GIT_TAG "5.3.1") # 2026-03-17 (requires ITK >= 5.4.1; builds against ITK upstream main)
   else()
-    set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-    set(ELASTIX_GIT_TAG "5.2.0") # 2024-07-18
+    set(ELASTIX_GIT_TAG "5.1.0") # 2023-01-12
   endif()
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Builds on top of [@N-Dekker's PR #53](https://github.com/lassoan/SlicerElastix/pull/53) (ENH: Support elastix version 5.2 with ITK >= 5.4, drop ITK < 5.0). The first commit on this branch is Niels' work, preserved with his authorship intact.

This update incorporates the reviewer feedback from PR #53 and bumps the pin from elastix 5.2.0 → **5.3.1** (latest pinned release with the ITK6 missing-`;` fix), so SlicerElastix builds against ITK upstream main (v6 prep).

<details>
<summary>Why elastix 5.3.1 (not main HEAD)</summary>

ITK upstream main now wraps `itkSetMacro`/`itkGetMacro` with `ITK_MACROEND_NOOP_STATEMENT`, which requires the user `;` at the call site. Elastix 5.2.0 has a missing `;` at `Components/Optimizers/ConjugateGradient/itkGenericConjugateGradientOptimizer.h:114` that ITK upstream main flags as:

```
itkGenericConjugateGradientOptimizer.h:123:5: error: expected ';' before 'virtual'
```

Elastix 5.3.0 added [`COMP: Add missing semicolons to ITK macro calls`](https://github.com/SuperElastix/elastix/commit/9554422f0) which resolves the issue. **5.3.1** (2026-03-17) is the latest pinned release tag. Per maintainer feedback, this PR pins to the release tag rather than a moving `main` branch.

Elastix 5.3.1 requires ITK ≥ 5.4.1, which matches the existing `VERSION_GREATER_EQUAL 5.4` gate (Slicer main is already on ITK ≥ 5.4).

</details>

<details>
<summary>Adopted PR #53 review suggestions</summary>

Per @jcfr's review on PR #53:

- ✅ Add explicit `if(NOT DEFINED ITK_VERSION_MAJOR)` FATAL_ERROR check
- ✅ Put the preferred (most-recent) elastix version first in the `if/else`
- ✅ Use `VERSION_GREATER_EQUAL` (clearer than `VERSION_EQUAL ... OR VERSION_GREATER ...`)
- ✅ Move the common `set(ELASTIX_GIT_REPOSITORY ...)` line out of both branches to reduce duplication

Per @N-Dekker's PR #53 (carried forward):

- ✅ Drop the ITK < 5.0 branch (Slicer no longer supports ITK 4)
- ✅ Fix the `"$https://..."` typo in the ELASTIX_GIT_REPOSITORY URL

</details>

<details>
<summary>Resulting File (just for reviewer convenience)</summary>

```cmake
  if(NOT DEFINED ITK_VERSION_MAJOR)
    message(FATAL_ERROR "Variable ITK_VERSION_MAJOR is expected to be defined.")
  endif()

  message(STATUS "ITK version: ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}.")
  set(ELASTIX_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
  if(${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR} VERSION_GREATER_EQUAL 5.4)
    set(ELASTIX_GIT_TAG "5.3.1") # 2026-03-17 (requires ITK >= 5.4.1; builds against ITK upstream main)
  else()
    set(ELASTIX_GIT_TAG "5.1.0") # 2023-01-12
  endif()
```

</details>

<details>
<summary>Verified</summary>

Compiles cleanly against:

- ITK upstream main (`Slicer/ITK` fork branch `slicer-upstream-main-namespace-2026-05-10` at `adccfa015c` = `InsightSoftwareConsortium/ITK` main + opt-in `itkNamespace.h` shim) with `ITK_FUTURE_LEGACY_REMOVE=ON`, Qt 6.8.2, gcc 13.3, Linux x86_64.
- ITK 5.4.6 (`Slicer/ITK` fork @ `5bfed919`) via the dual-target SlicerExtensions dashboard tracked at [Slicer/Slicer#9149](https://github.com/Slicer/Slicer/issues/9149).

</details>

<details>
<summary>Tracking</summary>

Part of the broader Slicer ITK upstream-main (v6) transition: [Slicer/Slicer#9149](https://github.com/Slicer/Slicer/issues/9149).

SlicerElastix was one of 7 extensions surfaced by a dual-target ITK 5.4.6 / ITK main dashboard as packaging on ITK 5.4.6 but failing on ITK main. This PR closes that gap.

</details>

<!--
provenance: claude-code session 2026-05-11 (johnsonhj-rxblue)
builds_on_pr: lassoan/SlicerElastix#53 (@N-Dekker)
review_feedback_from: @jcfr on lassoan/SlicerElastix#53
elastix_pin_before: 5.1.0 (master)
elastix_pin_after: 5.3.1 (5.3.0 added the missing-; fix; 5.3.1 is current release)
slicer_itk_branch: https://github.com/Slicer/ITK/tree/slicer-upstream-main-namespace-2026-05-10 @ adccfa015c
related_prs: netstim/SlicerANTs#17, Slicer/Slicer#9149
-->
